### PR TITLE
Address kubernetes secrets creation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,26 @@ Go to https://console.developers.google.com/apis/api/container.googleapis.com/ov
 ### Create base infrastructure
 - Start to create a service account key (credfile) which will be used to run Terraform commands. Follow the instructions at https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys. The service account to use is the one who starts with "project-factory" in the seed-project.
 
-- Create a new repository/local folder which will contain your configuration files using the 'example' folder as a template. 
+- Create a new repository/local folder which will contain your configuration files using the `example` folder as a template.
 
 - Update the variable values in `main.tf`
 
 - Update the values in the `backend.tf` file to reflect the location of your Terraform state file.
 
-- Update the values in `azure.tfvars`. This file is used to authenticate to Azure for DNS and Github for Atlantis-Github integration. The values for *gh-webhook-secret* and *gh-key-file* will be filled in later.
-
-Update the files under `kubernetes-manifests` as outlined.
+- Update the values in `azure.tfvars`. This file is used to authenticate to Azure for DNS.
 
 - Run terraform from the path where `main.tf` is located
 ```bash
+# Run Terraform init first:
+$ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credfile/ terraform init
+
 # Terraform plan to to check the execution plan
 $ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credfile/ terraform plan -var-file=azure.tfvars
 
 # Terraform to apply the changes
 $ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credfile/ terraform apply -var-file=azure.tfvars
 ```
+- Update the files under `kubernetes-manifests/cert-manager` and `kubernetes-manifests/runfirst` as outlined.
 
 ### Install applications
 ```bash
@@ -54,21 +56,16 @@ $ kubectl apply -k kubernetes-manifests/runfirst
 Visit this URL https://$ATLANTIS_HOST/github-app/setup and follow the instructions here https://www.runatlantis.io/docs/access-credentials.html#generating-an-access-token
 
 On the "Github app created successfully" page you will see the gh-app-id, gh-app-key-file and gh-webhook-secret.
-Update the `kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml` with the new gh-app-id and the `azure.tfvars` with the `gh-webhook-secret` and `gh-app-key-file`.   
+Update the `kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml` with the new gh-app-id and the other outlined variables.   
+The files `kubernetes-manifests/atlantis-statefulset/gh-webhook-secret` and `kubernetes-manifests/atlantis-statefulset/gh-key-file` also needs to be updated to reflect gh-app-key-file and gh-webhook-secret from the step above.   
 **Note!** It is important that the *gh-key-file* is kept with this specific format.   
-Set the variable *create_secret* in `azure.tfvars` to *true*.   
 **WARNING - Only a single Atlantis installation per GitHub App is supported at the moment**
 
 ```bash
-# In order to create kubernetes secrets of gh-app-key-file and gh-webhook-secret, run terraform again.
-$ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credfile/ terraform plan -var-file=azure.tfvars
-$ GOOGLE_APPLICATION_CREDENTIALS=/path/to/credfile/ terraform apply -var-file=azure.tfvars
-
 # Delete the "runfirst" deployment
 $ kubectl delete -k kubernetes-manifests/runfirst
 ```
 # Deploy Atlantis
-- Prior to applying the `kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml`, update *ATLANTIS_GH_APP_ID* as outlined in the file.
 ```bash
 $ kubectl apply -k kubernetes-manifests/atlantis-statefulset
 ```

--- a/example/azure.tfvars
+++ b/example/azure.tfvars
@@ -2,9 +2,4 @@ azure_subscription_id = "aaaaaaaa-1111-2222-bbbb-cccccccccccc"
 azure_client_id       = "11111111-2222-bbbb-cccc-333333333333"
 azure_client_secret   = "secret"
 azure_tenant_id       = "bbbbbbbb-2222-aaaa-cccc-111111111111"
-gh-webhook-secret     = "webhook-secret"
-gh-key-file           = <<CERT
------BEGIN RSA PRIVATE KEY-----
-cErTiFiCaTe
------END RSA PRIVATE KEY-----
-CERT
+

--- a/example/kubernetes-manifests/atlantis-statefulset/gh-key-file
+++ b/example/kubernetes-manifests/atlantis-statefulset/gh-key-file
@@ -1,0 +1,3 @@
+-----BEGIN RSA PRIVATE KEY-----
+insert key between begin and end tag
+-----END RSA PRIVATE KEY-----

--- a/example/kubernetes-manifests/atlantis-statefulset/gh-webhook-secret
+++ b/example/kubernetes-manifests/atlantis-statefulset/gh-webhook-secret
@@ -1,0 +1,1 @@
+insert webhook secret here

--- a/example/kubernetes-manifests/atlantis-statefulset/kustomization.yaml
+++ b/example/kubernetes-manifests/atlantis-statefulset/kustomization.yaml
@@ -5,3 +5,8 @@ bases:
 patchesStrategicMerge:
 - ingress.yaml
 - atlantis-statefulset.yaml
+secretGenerator:
+- name: atlantis
+  files:
+  - gh-webhook-secret
+  - gh-key-file

--- a/example/kubernetes-manifests/cert-manager/azure_client_secret
+++ b/example/kubernetes-manifests/cert-manager/azure_client_secret
@@ -1,0 +1,1 @@
+insert azure client secret here

--- a/example/kubernetes-manifests/cert-manager/kustomization.yaml
+++ b/example/kubernetes-manifests/cert-manager/kustomization.yaml
@@ -5,3 +5,7 @@ bases:
 patchesStrategicMerge:
 - cert-manager.yaml
 - certificate.yaml
+secretGenerator:
+- name: azure
+  files:
+  - azure_client_secret

--- a/example/main.tf
+++ b/example/main.tf
@@ -19,10 +19,7 @@ module "atlantis-test" {
     },
   ]
   azure_client_secret   = var.azure_client_secret
-  gh-key-file           = var.gh-key-file
   azure_subscription_id = var.azure_subscription_id
   azure_tenant_id       = var.azure_tenant_id
-  gh-webhook-secret     = var.gh-webhook-secret
   azure_client_id       = var.azure_client_id
-  create_secret         = false
 }

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -18,15 +18,3 @@ variable "azure_tenant_id" {
   type        = string
   description = "Azure tenant ID"
 }
-
-# Atlantis Github variables
-
-variable "gh-webhook-secret" {
-  type        = string
-  description = "Github Webhook secret"
-}
-
-variable "gh-key-file" {
-  type        = string
-  description = "Github App key"
-}

--- a/main.tf
+++ b/main.tf
@@ -75,9 +75,5 @@ module atlantis {
 
   project_id                 = module.gcp.project_id
   cluster_name               = module.gke.name
-  azure_client_secret        = var.azure_client_secret
-  create_secret              = var.create_secret
-  gh-webhook-secret          = var.gh-webhook-secret
-  gh-key-file                = var.gh-key-file
   master_authorized_networks = var.master_authorized_networks
 }

--- a/modules/atlantis/atlantis.tf
+++ b/modules/atlantis/atlantis.tf
@@ -17,31 +17,6 @@ module "kubernetes-engine_workload-identity" {
 }
 
 
-#---------------------------#
-# Create Kubernetes secrets #
-#---------------------------#
-resource "kubernetes_secret" "azure" {
-  metadata {
-    name = "azure"
-  }
-  data = {
-    azure_client_secret   = var.azure_client_secret
-  }
-}
-
-resource "kubernetes_secret" "atlantis" {
-  count = var.create_secret ? 1 : 0
-  
-  metadata {
-    name = "atlantis"
-  }
-  data = {
-    gh-webhook-secret   = var.gh-webhook-secret
-    gh-key-file         = var.gh-key-file
-  }
-}
-
-
 #--------------------------------------------------------#
 # Create Cloud Armor Security Policy to protect Atlantis #
 #--------------------------------------------------------#

--- a/modules/atlantis/variables.tf
+++ b/modules/atlantis/variables.tf
@@ -10,27 +10,6 @@ variable "cluster_name" {
   description = "Cluster name of the Kubernetes cluster"
 }
 
-variable "azure_client_secret" {
-  type        = string
-  description = "Azure client secret"
-}
-
-variable "create_secret" {
-  type        = string
-  default     = false
-  description = "Used to trigger creation of gh-atlantis secrets"
-}
-
-variable "gh-webhook-secret" {
-  type        = string
-  description = "Github Webhook secret"
-}
-
-variable "gh-key-file" {
-  type        = string
-  description = "Github App key"
-}
-
 variable "master_authorized_networks" {
   type = list(object({
     cidr_block   = string

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "azure_tenant_id" {
 }
 
 
-# GKE spacific svariables
+# GKE specific variables
 
 variable "master_authorized_networks" {
   type = list(object({
@@ -76,22 +76,4 @@ variable "zone_name" {
 variable "resource_group" {
   type        = string
   description = "Azure resource group name"
-}
-
-# Atlantis Github variables
-
-variable "create_secret" {
-  type        = string
-  default     = false
-  description = "Used to trigger creation of gh-atlantis secrets"
-}
-
-variable "gh-webhook-secret" {
-  type        = string
-  description = "Github Webhook secret"
-}
-
-variable "gh-key-file" {
-  type        = string
-  description = "Github App key"
 }


### PR DESCRIPTION
Had an issue when creating the kubernetes secrets from Terraform.
The secrets creation happened before the cluster was up and running,
hence it failed.
We have moved the secret generation to the kubernetes manifests.

Co-authored-by: Bjørn Vestli <bjorn.vestli@ssb.no>