### PR TITLE
Add Kubernetes provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,21 @@ provider github {
 }
 
 
+#--------------------------------------------------------#
+# Configure Kubernetes provider with OAuth2 access token #
+#--------------------------------------------------------#
+data "google_client_config" "default" {
+}
+
+provider "kubernetes" {
+  load_config_file = false
+
+  host  = "https://${module.gke.endpoint}"
+  token = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+}
+
+
 module gcp {
   source = "./modules/gcp"
 
@@ -57,6 +72,8 @@ module gke {
   project_id                 = module.gcp.project_id
   project_id_prefix          = var.project_id_prefix
   master_authorized_networks = var.master_authorized_networks
+  region                     = var.region
+  zone                       = var.zone
 }
 
 
@@ -76,4 +93,6 @@ module atlantis {
   project_id                 = module.gcp.project_id
   cluster_name               = module.gke.name
   master_authorized_networks = var.master_authorized_networks
+
+  depends_on = [module.gke]
 }

--- a/modules/atlantis/atlantis.tf
+++ b/modules/atlantis/atlantis.tf
@@ -4,12 +4,13 @@ locals {
 
 data "github_ip_ranges" "gh" {}
 
+
 #-----------------------------------------#
 # Create a Workload Identity for Atlantis #
 #-----------------------------------------#
 module "kubernetes-engine_workload-identity" {
   source       = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version      = "~> 11.0"
+  version      = "~> 10.0"
   cluster_name = var.cluster_name
   name         = "atlantis"
   namespace    = "default"

--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -37,13 +37,6 @@ module "vpc" {
 }
 
 
-resource "time_sleep" "wait_10_seconds" {
-  depends_on = [module.vpc]
-
-  create_duration = "10s"
-}
-
-
 #------------------#
 # Create Cloud NAT #
 #------------------#
@@ -63,8 +56,6 @@ module "cloud-nat" {
 # Create a private Kubernetes cluster #
 #-------------------------------------#
 module "private-cluster" {
-  depends_on = [time_sleep.wait_10_seconds]
-
   source                             = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   version                            = "~> 11.0"
 

--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -37,6 +37,13 @@ module "vpc" {
 }
 
 
+resource "time_sleep" "wait_10_seconds" {
+  depends_on = [module.vpc]
+
+  create_duration = "10s"
+}
+
+
 #------------------#
 # Create Cloud NAT #
 #------------------#
@@ -56,6 +63,8 @@ module "cloud-nat" {
 # Create a private Kubernetes cluster #
 #-------------------------------------#
 module "private-cluster" {
+  depends_on = [time_sleep.wait_10_seconds]
+
   source                             = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   version                            = "~> 11.0"
 

--- a/modules/gke/outputs.tf
+++ b/modules/gke/outputs.tf
@@ -1,3 +1,11 @@
 output name {
   value = module.private-cluster.name
 }
+
+output endpoint {
+  value = module.private-cluster.endpoint
+}
+
+output ca_certificate {
+  value = module.private-cluster.ca_certificate
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,18 @@ variable "master_authorized_networks" {
   description = "The list of CIDR blocks of master authorized networks"
 }
 
+variable "region" {
+  type        = string
+  default     = "europe-north1"
+  description = "Region in which to create the cluster and run Atlantis."
+}
+
+variable "zone" {
+  type        = string
+  default     = "europe-north1-a"
+  description = "GCP zone in which to create the cluster and run Atlantis"
+}
+
 
 # Ingress variables
 


### PR DESCRIPTION
This will add the Kubernetes provider to the root module so
that the resources that connects to Kubernetes will work.
At the moment this is Workload Identity.

This will also add support to override the zone and region where the Kubernetes cluster will be created.

There was also a bug when creating workload identity so we downgrade this to v10 again.