### PR TITLE
Add apply_requirements variable

### DIFF
--- a/example/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
+++ b/example/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
@@ -17,6 +17,7 @@ spec:
         - name: ATLANTIS_DATA_DIR
         - name: ATLANTIS_PORT
         - name: ATLANTIS_ATLANTIS_URL
+        - name: ATLANTIS_REPO_CONFIG_JSON
         env:
         - name: ATLANTIS_REPO_WHITELIST
           value: github.com/org/repo # Update me

--- a/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
+++ b/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
@@ -54,6 +54,8 @@ spec:
           value: "4141" # Kubernetes sets an ATLANTIS_PORT variable so we need to override.
         - name: ATLANTIS_ATLANTIS_URL
           value: https://atlantis-test.example.com  # 4. Update according to your configuration
+        - name: ATLANTIS_REPO_CONFIG_JSON
+          value: '{"repos":[{"id":"/.*/", "apply_requirements":["approved"]}]}'
         volumeMounts:
         - name: atlantis-data
           mountPath: /atlantis


### PR DESCRIPTION
This config adds an environment variable to only allow `atlantis apply` to be
 run on approved PRs.

When using this config on the (kustomize) base side it is required that you also provide the variable `ATLANTIS_REPO_CONFIG_JSON` in the patch side as shown in the provided example file: `example/kubernetes-manifests/atlantis-statefulset`.


Internal ref: [BIP-118]

Co-authored-by: @ArielKarlsen 