### PR TITLE
Update Ingress APIVersion from v1beta1 to v1 + update image repo ref. 

### DIFF
--- a/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
+++ b/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
             path: atlantis-app-key.pem
       containers:
       - name: atlantis
-        image: runatlantis/atlantis:v0.15.0 # 1. Replace <VERSION> with the most recent release.
+        image: ghcr.io/runatlantis/atlantis:v0.17.4 # 1. Replace <VERSION> with the most recent release.
         env:
         - name: ATLANTIS_REPO_WHITELIST
           value: github.com/<github organization>/<repo name> # 2. Replace this with your own repo whitelist. https://www.runatlantis.io/docs/server-configuration.html#flags

--- a/kubernetes-manifests/atlantis-statefulset/ingress.yaml
+++ b/kubernetes-manifests/atlantis-statefulset/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: atlantis-ingress
@@ -14,5 +14,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: atlantis
-          servicePort: 80
+          service:
+            name: atlantis
+            port: 
+              number: 80
+        pathType: ImplementationSpecific


### PR DESCRIPTION
Newer versions of the Atlantis image will be published at GHCR instead
of Docker hub, so the image string now has to start with `ghcr.io`.

The apiVersion `networking.k8s.io/v1beta1` is being deprecated.
From K8s v. 1.19, `networking.k8s.io/v1` is available. From K8s v.
1.22, the v1beta1 version is no longer served.
Ref. https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122

This change was tested using the atlantis-prod repo and doing a
server-side dry-run of the config.

Internal ref [STRATUS-504]

Co-authored-by: ArielKarlsen <54323769+ArielKarlsen@users.noreply.github.com>

[STRATUS-504]: https://statistics-norway.atlassian.net/browse/STRATUS-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ