### PR TITLE
Adapt to team atlantis config

### DIFF
--- a/kubernetes-manifests/runfirst/ingress.yaml
+++ b/kubernetes-manifests/runfirst/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: atlantis-ingress
@@ -14,5 +14,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: atlantis
-          servicePort: 80
+          service:
+            name: atlantis
+            port:
+              number: 80
+        pathType: ImplementationSpecific

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ provider "azurerm" {
 #------------------#
 # GitHub providers #
 #------------------#
-provider github {
+provider "github" {
   version = "2.9.2"
 }
 
@@ -48,13 +48,13 @@ data "google_client_config" "default" {
 provider "kubernetes" {
   load_config_file = false
 
-  host  = "https://${module.gke.endpoint}"
-  token = data.google_client_config.default.access_token
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
 
-module gcp {
+module "gcp" {
   source = "./modules/gcp"
 
   project_name      = var.project_name
@@ -66,7 +66,7 @@ module gcp {
 }
 
 
-module gke {
+module "gke" {
   source = "./modules/gke"
 
   project_id                 = module.gcp.project_id
@@ -77,7 +77,7 @@ module gke {
 }
 
 
-module ingress {
+module "ingress" {
   source = "./modules/ingress"
 
   project_id        = module.gcp.project_id
@@ -87,7 +87,7 @@ module ingress {
 }
 
 
-module atlantis {
+module "atlantis" {
   source = "./modules/atlantis"
 
   project_id                 = module.gcp.project_id

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,7 @@ module "ingress" {
 
   project_id        = module.gcp.project_id
   project_id_prefix = var.project_id_prefix
+  external_ip_name  = var.external_ip_name
   zone_name         = var.zone_name
   resource_group    = var.resource_group
 }

--- a/modules/gcp/outputs.tf
+++ b/modules/gcp/outputs.tf
@@ -1,3 +1,3 @@
-output project_id {
+output "project_id" {
   value = module.project-factory.project_id
 }

--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -56,8 +56,8 @@ module "cloud-nat" {
 # Create a private Kubernetes cluster #
 #-------------------------------------#
 module "private-cluster" {
-  source                             = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
-  version                            = "~> 11.0"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
+  version = "~> 11.0"
 
   project_id                         = var.project_id
   name                               = var.project_id_prefix

--- a/modules/gke/outputs.tf
+++ b/modules/gke/outputs.tf
@@ -1,11 +1,11 @@
-output name {
+output "name" {
   value = module.private-cluster.name
 }
 
-output endpoint {
+output "endpoint" {
   value = module.private-cluster.endpoint
 }
 
-output ca_certificate {
+output "ca_certificate" {
   value = module.private-cluster.ca_certificate
 }

--- a/modules/ingress/ingress.tf
+++ b/modules/ingress/ingress.tf
@@ -6,7 +6,7 @@ module "address-fe" {
   source     = "terraform-google-modules/address/google"
   version    = "~> 2.0"
   project_id = var.project_id
-  names      = ["atlantis-external-facing-ip"]
+  names      = [var.external_ip_name]
   global     = true
   region     = var.region
 }

--- a/modules/ingress/ingress.tf
+++ b/modules/ingress/ingress.tf
@@ -3,12 +3,12 @@
 #-------------------------------------#
 
 module "address-fe" {
-  source  = "terraform-google-modules/address/google"
-  version = "~> 2.0"
-  project_id   = var.project_id
-  names  = [ "atlantis-external-facing-ip"]
-  global = true
-  region = var.region
+  source     = "terraform-google-modules/address/google"
+  version    = "~> 2.0"
+  project_id = var.project_id
+  names      = ["atlantis-external-facing-ip"]
+  global     = true
+  region     = var.region
 }
 
 #-------------------------------------------------------#

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -25,3 +25,8 @@ variable "resource_group" {
   type        = string
   description = "Azure resource group name"
 }
+
+variable "external_ip_name" {
+  type        = string
+  description = "Name of the external IP address resource in GCP"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,8 @@ variable "resource_group" {
   type        = string
   description = "Azure resource group name"
 }
+
+variable "external_ip_name" {
+  type        = string
+  description = "Name of the external IP address resource in GCP"
+}


### PR DESCRIPTION
Introduce "IP name" variable in ingress module

This is done to make the ingress module usable by the team Atlantis
configurations.
(The external IP address resources created in GCP should have
different names. This change enables setting unique names for
every Atlantis instance. Without the change, all of them would have
the same name.)

Also, Update runfirst Ingress manifest to use the right API version.

Internal ref [STRATUS-968]

Co-authored-by: ArielKarlsen <54323769+ArielKarlsen@users.noreply.github.com>
Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>

[STRATUS-968]: https://statistics-norway.atlassian.net/browse/STRATUS-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ