### PR TITLE
Lock Cloud NAT version

### DIFF
--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -42,7 +42,7 @@ module "vpc" {
 #------------------#
 module "cloud-nat" {
   source  = "terraform-google-modules/cloud-nat/google"
-  version = "~> 1.3"
+  version = "1.3"
 
   project_id    = var.project_id
   region        = var.region


### PR DESCRIPTION
Due to breaking changes in Cloud NAT module, we will lock the version
we are using to 1.3
This should be looked at in the future to handle the newest version of
the module.

Co-authored-by: lisawolderiksen <35797988+lisawolderiksen@users.noreply.github.com>
Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>