### PR TITLE
Prepare for upgrade of cert-manager to version 1.7.1

### DIFF
--- a/example/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
+++ b/example/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
@@ -5,25 +5,13 @@ metadata:
 spec:
   template:
     spec:
-      $setElementOrder/containers:
-      - name: atlantis
       containers:
-      - $setElementOrder/env:
-        - name: ATLANTIS_REPO_ALLOWLIST
-        - name: ATLANTIS_GH_APP_ID
-        - name: ATLANTIS_GH_APP_KEY_FILE
-        - name: ATLANTIS_GH_WEBHOOK_SECRET
-        - name: ATLANTIS_WRITE_GIT_CREDS
-        - name: ATLANTIS_DATA_DIR
-        - name: ATLANTIS_PORT
-        - name: ATLANTIS_ATLANTIS_URL
-        - name: ATLANTIS_REPO_CONFIG_JSON
-        env:
+      - env:
         - name: ATLANTIS_REPO_ALLOWLIST
           value: github.com/org/repo # Update me
         - name: ATLANTIS_GH_APP_ID
           value: "12345" # Update me after GitHub app is created
         - name: ATLANTIS_ATLANTIS_URL
           value: https://atlantis-test.example.com # Update me
-        image: runatlantis/atlantis:v0.15.0 # Update me
+        image: runatlantis/atlantis:v0.18.2 # Update to latest
         name: atlantis

--- a/example/kubernetes-manifests/atlantis-statefulset/ingress.yaml
+++ b/example/kubernetes-manifests/atlantis-statefulset/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,5 +12,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: atlantis
-          servicePort: 80
+          service:
+            name: atlantis
+            port:
+              number: 80
+        pathType: ImplementationSpecific
+

--- a/example/kubernetes-manifests/atlantis-statefulset/kustomization.yaml
+++ b/example/kubernetes-manifests/atlantis-statefulset/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/atlantis-statefulset?ref=main
+- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/atlantis-statefulset?ref=v3.0.0
 patchesStrategicMerge:
 - ingress.yaml
 - atlantis-statefulset.yaml

--- a/example/kubernetes-manifests/cert-manager/cert-manager.yaml
+++ b/example/kubernetes-manifests/cert-manager/cert-manager.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt

--- a/example/kubernetes-manifests/cert-manager/certificate.yaml
+++ b/example/kubernetes-manifests/cert-manager/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate

--- a/example/kubernetes-manifests/cert-manager/kustomization.yaml
+++ b/example/kubernetes-manifests/cert-manager/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/cert-manager?ref=main
+- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/cert-manager?ref=v3.0.0
 patchesStrategicMerge:
 - cert-manager.yaml
 - certificate.yaml

--- a/example/kubernetes-manifests/runfirst/atlantis-runfirst.yaml
+++ b/example/kubernetes-manifests/runfirst/atlantis-runfirst.yaml
@@ -7,19 +7,11 @@ metadata:
 spec:
   template:
     spec:
-      $setElementOrder/containers:
-      - name: atlantis
       containers:
-      - $setElementOrder/env:
-        - name: ATLANTIS_REPO_ALLOWLIST
-        - name: ATLANTIS_GH_USER
-        - name: ATLANTIS_GH_TOKEN
-        - name: ATLANTIS_PORT
-        - name: ATLANTIS_ATLANTIS_URL
-        env:
+      - env:
         - name: ATLANTIS_REPO_ALLOWLIST
           value: github.com/org/repo # Update me
         - name: ATLANTIS_ATLANTIS_URL
           value: https://atlantis-test.example.com # Update me
-        image: runatlantis/atlantis:v0.15.0 # update me
+        image: runatlantis/atlantis:v0.18.2 # Update to latest
         name: atlantis

--- a/example/kubernetes-manifests/runfirst/ingress.yaml
+++ b/example/kubernetes-manifests/runfirst/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -12,5 +12,8 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: atlantis
-          servicePort: 80
+          service:
+            name: atlantis
+            port:
+              number: 80
+        pathType: ImplementationSpecific

--- a/example/kubernetes-manifests/runfirst/kustomization.yaml
+++ b/example/kubernetes-manifests/runfirst/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/runfirst?ref=main
+- https://github.com/statisticsnorway/atlantis-bootstrap/kubernetes-manifests/runfirst?ref=v3.0.0
 patchesStrategicMerge:
 - ingress.yaml
 - atlantis-runfirst.yaml

--- a/example/main.tf
+++ b/example/main.tf
@@ -22,4 +22,5 @@ module "atlantis-test" {
   azure_subscription_id = var.azure_subscription_id
   azure_tenant_id       = var.azure_tenant_id
   azure_client_id       = var.azure_client_id
+  external_ip_name      = "atlantis-external-facing-ip"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,5 @@
 module "atlantis-test" {
-  #  source = "github-com/statisticsnorway/atlantis-bootstrap"
-  source = "github.com/statisticsnorway/atlantis-bootstrap"
+  source = "github.com/statisticsnorway/atlantis-bootstrap?ref=v3.0.0"
 
   org_id            = "123456789123"         # GCP organization ID
   zone_name         = "example.com"          # DNS zone name in Azure

--- a/kubernetes-manifests/cert-manager/cert-manager.yaml
+++ b/kubernetes-manifests/cert-manager/cert-manager.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt

--- a/kubernetes-manifests/cert-manager/certificate.yaml
+++ b/kubernetes-manifests/cert-manager/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1beta1
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-certificate


### PR DESCRIPTION
f52dc266755e18389412bfba0af3653dffbaf352 - Change cert-manager apis from beta to v1
39b975aab21ae141bd1cc00caa7980fb950214ba - Update examples
e645e1dd7dcc7650caa1282c38d139e6ffede4a4 - Lock example to specific version

Internal ref: [STRATUS-998]

Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>

[STRATUS-998]: https://statistics-norway.atlassian.net/browse/STRATUS-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ