### PR TITLE
Update docs with url for new cert-manager version

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ gcloud init
 $ gcloud container clusters get-credentials <CLUSTER NAME> --project <PROJECT ID> --region <REGION>
 
 # Install cert-manager. Check for latest version
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml
+$ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 
 # Create TLS certificate
 $ kubectl apply -k kubernetes-manifests/cert-manager


### PR DESCRIPTION
Updated the documentation with the new url used when installing
cert-manager to now use version 1.7.1.

Internal-ref: [STRATUS-988]

Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>