### PR TITLE
Fix version of k8s provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.8.0"
+      version = "1.13.0"
     }
     github = {
       source  = "hashicorp/github"


### PR DESCRIPTION
The given version of the k8s provider was not compatible with the
actual code in the module (running `terraform plan` revealed a lot of
error messages about version troubles).

We set the provider version to the newest version supporting the
`load_config_file` argument in the provider config.
Now, running `terraform plan` results in a successful plan with
no changes.

Internal ref [STRATUS-1091]

Co-authored-by: nomx3 <aet@ssb.no>
Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>

[STRATUS-1091]: https://statistics-norway.atlassian.net/browse/STRATUS-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ