### PR TITLE
Enable "cloudkms.googleapis.com"

### DIFF
--- a/modules/gcp/variables.tf
+++ b/modules/gcp/variables.tf
@@ -17,7 +17,15 @@ variable "org_id" {
 
 variable "activate_apis" {
   type        = list(string)
-  default     = ["container.googleapis.com", "iam.googleapis.com", "admin.googleapis.com", "compute.googleapis.com", "secretmanager.googleapis.com", "iap.googleapis.com"]
+  default     = [
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "admin.googleapis.com",
+    "compute.googleapis.com",
+    "secretmanager.googleapis.com",
+    "iap.googleapis.com",
+    "cloudkms.googleapis.com"
+  ]
   description = "The list of apis to activate within the project"
 }
 


### PR DESCRIPTION
The Cloud KMS API is needed in the atlantis-prod
project in order to create key rings in team projects.

Co-authored-by: ssbdif <35797607+ssbdif@users.noreply.github.com>