### PR TITLE
Allow running atlantis plan on draft PR's

### DIFF
--- a/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
+++ b/kubernetes-manifests/atlantis-statefulset/atlantis-statefulset.yaml
@@ -56,6 +56,8 @@ spec:
           value: https://atlantis-test.example.com  # 4. Update according to your configuration
         - name: ATLANTIS_REPO_CONFIG_JSON
           value: '{"repos":[{"id":"/.*/", "apply_requirements":["approved"]}]}'
+        - name: ATLANTIS_ALLOW_DRAFT_PRS
+          value: "true"
         volumeMounts:
         - name: atlantis-data
           mountPath: /atlantis


### PR DESCRIPTION
Sometimes you want to test if a change made in a dependent module works
before you create the PR.