### PR TITLE
Update kubernetes-engine module to v22

### DIFF
--- a/modules/atlantis/atlantis.tf
+++ b/modules/atlantis/atlantis.tf
@@ -9,7 +9,7 @@ data "github_ip_ranges" "gh" {}
 #-----------------------------------------#
 module "kubernetes-engine_workload-identity" {
   source          = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  version         = "~> 21.0"
+  version         = "~> 22.0"
   cluster_name    = var.cluster_name
   name            = "atlantis"
   namespace       = "default"

--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -57,7 +57,7 @@ module "cloud-nat" {
 #-------------------------------------#
 module "private-cluster" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version = "~> 21.0"
+  version = "~> 22.0"
 
   project_id                         = var.project_id
   name                               = var.project_id_prefix


### PR DESCRIPTION
A new version of the terraform module `kubernetes-engine` is available.
This PR will update the version from `v21 `to `v22`.
The new version have some breaking changes, but should not affect our
use of the module. Ref. change log: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/releases/tag/v22.0.0

Internal ref.[STRATUS-877]

[STRATUS-877]: https://statistics-norway.atlassian.net/browse/STRATUS-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ